### PR TITLE
fix: trim github notification message - RK-19530 

### DIFF
--- a/pkg/event_handler/github_event_notifier.go
+++ b/pkg/event_handler/github_event_notifier.go
@@ -6,6 +6,7 @@ import (
 	"github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/rookout/piper/pkg/clients"
 	"github.com/rookout/piper/pkg/conf"
+	"github.com/rookout/piper/pkg/utils"
 )
 
 var workflowTranslationToGithubMap = map[string]string{
@@ -48,7 +49,7 @@ func (gn *githubNotifier) Notify(ctx *context.Context, workflow *v1alpha1.Workfl
 		return fmt.Errorf("failed to translate workflow status to github stasuts for %s status: %s", workflow.GetName(), workflow.Status.Phase)
 	}
 
-	message := workflow.Status.Message
+	message := utils.TrimString(workflow.Status.Message, 140) // Max length of message is 140 characters
 	err := gn.clients.GitProvider.SetStatus(ctx, &repo, &commit, &workflowLink, &status, &message)
 	if err != nil {
 		return fmt.Errorf("failed to set status for workflow %s: %s", workflow.GetName(), err)

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -131,3 +131,10 @@ func ValidateHTTPFormat(input string) bool {
 	match, _ := regexp.MatchString(regex, input)
 	return match
 }
+
+func TrimString(s string, maxLength int) string {
+	if maxLength >= len(s) {
+		return s
+	}
+	return s[:maxLength]
+}

--- a/pkg/utils/common_test.go
+++ b/pkg/utils/common_test.go
@@ -303,3 +303,25 @@ func TestValidateHTTPFormat(t *testing.T) {
 	}
 
 }
+
+func TestTrimString(t *testing.T) {
+	assert := assertion.New(t)
+
+	// Test cases
+	testCases := []struct {
+		input     string
+		maxLength int
+		expected  string
+	}{
+		{"This is a sample string.", 10, "This is a "},
+		{"Short", 10, "Short"},
+		{"Longer string for testing.", 5, "Longe"},
+		{"", 10, ""},
+	}
+
+	// Perform tests
+	for _, tc := range testCases {
+		result := TrimString(tc.input, tc.maxLength)
+		assert.Equal(tc.expected, result)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Gosha <gosha@rookout.com>

## Pull Request

### Description

Github notification gets 422 error because the message too long. 
![Screenshot 2023-07-26 at 19 10 20](https://github.com/Rookout/piper/assets/106976988/99149cb1-5bc0-4d00-a2aa-3c60ae68d0bb)


### Checklist

Before submitting this pull request, please ensure that you have completed the following tasks:

- [x] Reviewed the [Contributing Guidelines](../docs/CONTRIBUTING.md) for the Piper project.
- [x] Ensured that your changes follow the [coding guidelines and style](../docs/CONTRIBUTING.md#coding-guidelines) of the project.
- [x] Run the tests locally and made sure they pass.
- [x] Updated the relevant documentation, if applicable.

